### PR TITLE
refactor: typed required-element helper for popup/options

### DIFF
--- a/src/options/options.ts
+++ b/src/options/options.ts
@@ -13,6 +13,7 @@ import { readHistoryFilters, resetHistoryFilters } from "./history-filters";
 import { readDefaultContextSelection, renderDefaultContextOptions } from "./default-context";
 import type { Shortcut } from "../types/api";
 import type { HistoryItem, HistoryStats } from "../types/storage";
+import { requireElement } from "../utils/dom/required-element";
 import { sendRuntimeMessage } from "../utils/io/runtime-message";
 
 /**
@@ -20,7 +21,7 @@ import { sendRuntimeMessage } from "../utils/io/runtime-message";
  */
 async function refreshShortcutList(): Promise<void> {
   const shortcuts = await sendRuntimeMessage<Shortcut[]>({ type: "shortcuts:list" });
-  const container = document.getElementById("shortcuts") as HTMLElement;
+  const container = requireElement<HTMLElement>("shortcuts");
   renderShortcutList(container, shortcuts);
 }
 
@@ -28,7 +29,7 @@ async function refreshShortcutList(): Promise<void> {
  * Loads shortcuts and settings, then renders default context selector.
  */
 async function refreshDefaultContextSelector(): Promise<void> {
-  const select = document.getElementById("default-context-shortcut") as HTMLSelectElement;
+  const select = requireElement<HTMLSelectElement>("default-context-shortcut");
   const shortcuts = await sendRuntimeMessage<Shortcut[]>({ type: "shortcuts:list" });
   const settings = await sendRuntimeMessage<{ defaultContextShortcutId: string | null }>({ type: "settings:get" });
   renderDefaultContextOptions(select, shortcuts, settings.defaultContextShortcutId);
@@ -39,15 +40,15 @@ async function refreshDefaultContextSelector(): Promise<void> {
  */
 async function refreshHistoryList(): Promise<void> {
   const history = await sendRuntimeMessage<HistoryItem[]>({ type: "history:list" });
-  const container = document.getElementById("options-history") as HTMLElement;
-  const statsElement = document.getElementById("options-history-stats") as HTMLElement;
+  const container = requireElement<HTMLElement>("options-history");
+  const statsElement = requireElement<HTMLElement>("options-history-stats");
   const filters = readHistoryFilters({
-    source: document.getElementById("history-source-filter") as HTMLSelectElement,
-    result: document.getElementById("history-result-filter") as HTMLSelectElement,
-    query: document.getElementById("history-query-filter") as HTMLInputElement,
-    sort: document.getElementById("history-sort-mode") as HTMLSelectElement,
-    maxItems: document.getElementById("history-max-items") as HTMLSelectElement,
-    minDurationMs: document.getElementById("history-min-duration") as HTMLInputElement
+    source: requireElement<HTMLSelectElement>("history-source-filter"),
+    result: requireElement<HTMLSelectElement>("history-result-filter"),
+    query: requireElement<HTMLInputElement>("history-query-filter"),
+    sort: requireElement<HTMLSelectElement>("history-sort-mode"),
+    maxItems: requireElement<HTMLSelectElement>("history-max-items"),
+    minDurationMs: requireElement<HTMLInputElement>("history-min-duration")
   });
   const stats = await sendRuntimeMessage<HistoryStats>({ type: "history:stats" });
   const sourceFiltered = filterHistoryBySource(history, filters.source);
@@ -64,7 +65,7 @@ async function refreshHistoryList(): Promise<void> {
  * Renders user-facing status messages in the options page.
  */
 function setStatus(message: string): void {
-  const statusElement = document.getElementById("status") as HTMLElement;
+  const statusElement = requireElement<HTMLElement>("status");
   statusElement.textContent = message;
 }
 
@@ -92,7 +93,7 @@ async function deleteShortcut(shortcutId: string): Promise<void> {
  * Exports current state into options import/export textarea.
  */
 async function exportStateToTextarea(): Promise<void> {
-  const textarea = document.getElementById("state-json") as HTMLTextAreaElement;
+  const textarea = requireElement<HTMLTextAreaElement>("state-json");
   const result = await sendRuntimeMessage<{ json: string }>({ type: "state:export" });
   textarea.value = result.json;
 }
@@ -101,7 +102,7 @@ async function exportStateToTextarea(): Promise<void> {
  * Imports state from options import/export textarea.
  */
 async function importStateFromTextarea(): Promise<void> {
-  const textarea = document.getElementById("state-json") as HTMLTextAreaElement;
+  const textarea = requireElement<HTMLTextAreaElement>("state-json");
   await sendRuntimeMessage({ type: "state:import", payload: { json: textarea.value } });
   await refreshShortcutList();
   await refreshHistoryList();
@@ -119,7 +120,7 @@ async function clearHistory(): Promise<void> {
  * Saves selected default shortcut for context menu execution.
  */
 async function saveDefaultContextShortcut(): Promise<void> {
-  const select = document.getElementById("default-context-shortcut") as HTMLSelectElement;
+  const select = requireElement<HTMLSelectElement>("default-context-shortcut");
   const defaultContextShortcutId = readDefaultContextSelection(select);
   await sendRuntimeMessage({ type: "settings:update", payload: { defaultContextShortcutId } });
 }
@@ -128,19 +129,19 @@ async function saveDefaultContextShortcut(): Promise<void> {
  * Initializes options page interactions.
  */
 async function initOptionsPage(): Promise<void> {
-  const saveButton = document.getElementById("save-btn") as HTMLButtonElement;
-  const exportButton = document.getElementById("export-btn") as HTMLButtonElement;
-  const importButton = document.getElementById("import-btn") as HTMLButtonElement;
-  const clearHistoryButton = document.getElementById("clear-history-options-btn") as HTMLButtonElement;
-  const saveDefaultContextButton = document.getElementById("save-default-context-btn") as HTMLButtonElement;
-  const historySourceFilter = document.getElementById("history-source-filter") as HTMLSelectElement;
-  const historyResultFilter = document.getElementById("history-result-filter") as HTMLSelectElement;
-  const historyQueryFilter = document.getElementById("history-query-filter") as HTMLInputElement;
-  const historySortMode = document.getElementById("history-sort-mode") as HTMLSelectElement;
-  const historyMaxItems = document.getElementById("history-max-items") as HTMLSelectElement;
-  const historyMinDuration = document.getElementById("history-min-duration") as HTMLInputElement;
-  const historyResetFiltersButton = document.getElementById("history-reset-filters-btn") as HTMLButtonElement;
-  const list = document.getElementById("shortcuts") as HTMLElement;
+  const saveButton = requireElement<HTMLButtonElement>("save-btn");
+  const exportButton = requireElement<HTMLButtonElement>("export-btn");
+  const importButton = requireElement<HTMLButtonElement>("import-btn");
+  const clearHistoryButton = requireElement<HTMLButtonElement>("clear-history-options-btn");
+  const saveDefaultContextButton = requireElement<HTMLButtonElement>("save-default-context-btn");
+  const historySourceFilter = requireElement<HTMLSelectElement>("history-source-filter");
+  const historyResultFilter = requireElement<HTMLSelectElement>("history-result-filter");
+  const historyQueryFilter = requireElement<HTMLInputElement>("history-query-filter");
+  const historySortMode = requireElement<HTMLSelectElement>("history-sort-mode");
+  const historyMaxItems = requireElement<HTMLSelectElement>("history-max-items");
+  const historyMinDuration = requireElement<HTMLInputElement>("history-min-duration");
+  const historyResetFiltersButton = requireElement<HTMLButtonElement>("history-reset-filters-btn");
+  const list = requireElement<HTMLElement>("shortcuts");
 
   saveButton.addEventListener("click", async () => {
     await runWithStatus(async () => {

--- a/src/popup/popup.ts
+++ b/src/popup/popup.ts
@@ -14,6 +14,7 @@ import { copyTextToClipboard } from "./clipboard";
 import { readPopupHistoryControls, resetPopupHistoryControls } from "./history-controls";
 import { extractTemplateVariables, promptTemplateVariables } from "./template-variables";
 import type { Shortcut } from "../types/api";
+import { requireElement } from "../utils/dom/required-element";
 import { sendRuntimeMessage } from "../utils/io/runtime-message";
 import type { HistoryItem, HistoryStats } from "../types/storage";
 
@@ -44,9 +45,9 @@ async function buildExecutionContext(): Promise<{ input: string; pageUrl: string
  * Loads recent history entries into popup list.
  */
 async function refreshHistory(): Promise<void> {
-  const historyElement = document.getElementById("history") as HTMLElement;
-  const filterElement = document.getElementById("popup-history-filter") as HTMLSelectElement;
-  const maxElement = document.getElementById("popup-history-max") as HTMLSelectElement;
+  const historyElement = requireElement<HTMLElement>("history");
+  const filterElement = requireElement<HTMLSelectElement>("popup-history-filter");
+  const maxElement = requireElement<HTMLSelectElement>("popup-history-max");
   const controls = readPopupHistoryControls({ filter: filterElement, maxItems: maxElement });
   const history = await sendRuntimeMessage<HistoryItem[]>({ type: "history:list" });
   const filtered = filterPopupHistory(history, controls.filter);
@@ -57,7 +58,7 @@ async function refreshHistory(): Promise<void> {
  * Loads aggregated history stats into popup summary line.
  */
 async function refreshHistoryStats(): Promise<void> {
-  const statsElement = document.getElementById("history-stats") as HTMLElement;
+  const statsElement = requireElement<HTMLElement>("history-stats");
   const stats = await sendRuntimeMessage<HistoryStats>({ type: "history:stats" });
   renderHistoryStats(statsElement, stats);
 }
@@ -66,15 +67,15 @@ async function refreshHistoryStats(): Promise<void> {
  * Initializes popup event handlers and data loading.
  */
 async function initPopup(): Promise<void> {
-  const selectElement = document.getElementById("shortcut-select") as HTMLSelectElement;
-  const resultElement = document.getElementById("result") as HTMLElement;
-  const statusElement = document.getElementById("popup-status") as HTMLElement;
-  const runButton = document.getElementById("run-btn") as HTMLButtonElement;
-  const copyResultButton = document.getElementById("copy-result-btn") as HTMLButtonElement;
-  const clearHistoryButton = document.getElementById("clear-history-btn") as HTMLButtonElement;
-  const historyFilter = document.getElementById("popup-history-filter") as HTMLSelectElement;
-  const historyMax = document.getElementById("popup-history-max") as HTMLSelectElement;
-  const historyReset = document.getElementById("popup-history-reset-btn") as HTMLButtonElement;
+  const selectElement = requireElement<HTMLSelectElement>("shortcut-select");
+  const resultElement = requireElement<HTMLElement>("result");
+  const statusElement = requireElement<HTMLElement>("popup-status");
+  const runButton = requireElement<HTMLButtonElement>("run-btn");
+  const copyResultButton = requireElement<HTMLButtonElement>("copy-result-btn");
+  const clearHistoryButton = requireElement<HTMLButtonElement>("clear-history-btn");
+  const historyFilter = requireElement<HTMLSelectElement>("popup-history-filter");
+  const historyMax = requireElement<HTMLSelectElement>("popup-history-max");
+  const historyReset = requireElement<HTMLButtonElement>("popup-history-reset-btn");
 
   const shortcuts = await sendRuntimeMessage<Shortcut[]>({ type: "shortcuts:list" });
   renderShortcutOptions(selectElement, shortcuts);

--- a/src/utils/dom/required-element.ts
+++ b/src/utils/dom/required-element.ts
@@ -1,0 +1,10 @@
+/**
+ * Returns a required element by id and throws if it is missing.
+ */
+export function requireElement<T extends HTMLElement>(id: string): T {
+  const element = document.getElementById(id);
+  if (!element) {
+    throw new Error(`Missing required element: #${id}`);
+  }
+  return element as T;
+}

--- a/tests/required-element.test.ts
+++ b/tests/required-element.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from "vitest";
+import { requireElement } from "../src/utils/dom/required-element";
+
+describe("requireElement", () => {
+  it("returns element when present", () => {
+    const fake = { id: "status", textContent: "" } as unknown as HTMLElement;
+    const originalDocument = globalThis.document;
+    const globalWithDocument = globalThis as unknown as {
+      document?: { getElementById: (id: string) => HTMLElement | null };
+    };
+    globalWithDocument.document = {
+      getElementById: (id: string) => (id === "status" ? fake : null)
+    };
+
+    try {
+      expect(requireElement<HTMLElement>("status")).toBe(fake);
+    } finally {
+      (globalThis as unknown as { document?: unknown }).document = originalDocument;
+    }
+  });
+
+  it("throws when missing", () => {
+    const originalDocument = globalThis.document;
+    const globalWithDocument = globalThis as unknown as {
+      document?: { getElementById: (_id: string) => null };
+    };
+    globalWithDocument.document = {
+      getElementById: () => null
+    };
+
+    try {
+      expect(() => requireElement<HTMLElement>("missing")).toThrowError("Missing required element: #missing");
+    } finally {
+      (globalThis as unknown as { document?: unknown }).document = originalDocument;
+    }
+  });
+});


### PR DESCRIPTION
## Summary
- add a shared `requireElement<T>()` helper for safe required DOM lookups
- use the helper in popup and options pages to remove repetitive `getElementById(...) as ...` casts
- add unit tests for helper success/failure behavior

## Validation
- make lint
- make typecheck
- make test
- make build
- make release-check-smoke