### PR TITLE
refactor: simplify background message router flow

### DIFF
--- a/src/background/message-router.ts
+++ b/src/background/message-router.ts
@@ -12,90 +12,81 @@ import { executeShortcut } from "./executor";
  * Routes runtime messages and returns async response payloads.
  */
 export async function handleRuntimeMessage(message: RuntimeMessage): Promise<unknown> {
-  if (message.type === "shortcuts:list") {
-    const state = await loadState();
-    return state.shortcuts;
-  }
-
-  if (message.type === "history:list") {
-    const state = await loadState();
-    return state.history;
-  }
-
-  if (message.type === "history:stats") {
-    const state = await loadState();
-    return summarizeHistory(state.history);
-  }
-
-  if (message.type === "history:clear") {
-    const state = await loadState();
-    await saveState({ ...state, history: [] });
-    return { cleared: true };
-  }
-
-  if (message.type === "settings:get") {
-    const state = await loadState();
-    return state.settings;
-  }
-
-  if (message.type === "shortcuts:save") {
-    const state = await loadState();
-    const shortcut = createShortcut(message.payload);
-    assertShortcutValid(shortcut);
-
-    const existing = state.shortcuts.filter((entry) => entry.id !== shortcut.id);
-    await saveState({ ...state, shortcuts: [shortcut, ...existing] });
-    return shortcut;
-  }
-
-  if (message.type === "shortcuts:delete") {
-    const state = await loadState();
-    const shortcuts = state.shortcuts.filter((entry) => entry.id !== message.payload.shortcutId);
-    await saveState({
-      ...state,
-      shortcuts,
-      settings: {
-        ...state.settings,
-        defaultContextShortcutId: resolveDefaultContextShortcutId(shortcuts, state.settings.defaultContextShortcutId)
-      }
-    });
-    return { deleted: true };
-  }
-
-  if (message.type === "settings:update") {
-    const state = await loadState();
-    const defaultContextShortcutId = resolveDefaultContextShortcutId(
-      state.shortcuts,
-      message.payload.defaultContextShortcutId
-    );
-
-    await saveState({
-      ...state,
-      settings: {
-        ...state.settings,
-        defaultContextShortcutId
-      }
-    });
-    return { saved: true };
-  }
-
-  if (message.type === "shortcut:run") {
-    return executeShortcut(message.payload.shortcutId, message.payload.context, "popup");
-  }
-
-  if (message.type === "state:export") {
-    const state = await loadState();
-    return { json: exportStateJson(state) };
-  }
-
-  if (message.type === "state:import") {
-    const state = importStateJson(message.payload.json);
-    if (!state) {
-      throw new AppError("STATE_IMPORT_INVALID_JSON", "State import payload is not valid JSON");
+  switch (message.type) {
+    case "shortcuts:list": {
+      const state = await loadState();
+      return state.shortcuts;
     }
-    await saveState(state);
-    return { imported: true, shortcuts: state.shortcuts.length };
-  }
+    case "history:list": {
+      const state = await loadState();
+      return state.history;
+    }
+    case "history:stats": {
+      const state = await loadState();
+      return summarizeHistory(state.history);
+    }
+    case "history:clear": {
+      const state = await loadState();
+      await saveState({ ...state, history: [] });
+      return { cleared: true };
+    }
+    case "settings:get": {
+      const state = await loadState();
+      return state.settings;
+    }
+    case "shortcuts:save": {
+      const state = await loadState();
+      const shortcut = createShortcut(message.payload);
+      assertShortcutValid(shortcut);
 
-  return null;
+      const existing = state.shortcuts.filter((entry) => entry.id !== shortcut.id);
+      await saveState({ ...state, shortcuts: [shortcut, ...existing] });
+      return shortcut;
+    }
+    case "shortcuts:delete": {
+      const state = await loadState();
+      const shortcuts = state.shortcuts.filter((entry) => entry.id !== message.payload.shortcutId);
+      await saveState({
+        ...state,
+        shortcuts,
+        settings: {
+          ...state.settings,
+          defaultContextShortcutId: resolveDefaultContextShortcutId(shortcuts, state.settings.defaultContextShortcutId)
+        }
+      });
+      return { deleted: true };
+    }
+    case "settings:update": {
+      const state = await loadState();
+      const defaultContextShortcutId = resolveDefaultContextShortcutId(
+        state.shortcuts,
+        message.payload.defaultContextShortcutId
+      );
+
+      await saveState({
+        ...state,
+        settings: {
+          ...state.settings,
+          defaultContextShortcutId
+        }
+      });
+      return { saved: true };
+    }
+    case "shortcut:run":
+      return executeShortcut(message.payload.shortcutId, message.payload.context, "popup");
+    case "state:export": {
+      const state = await loadState();
+      return { json: exportStateJson(state) };
+    }
+    case "state:import": {
+      const state = importStateJson(message.payload.json);
+      if (!state) {
+        throw new AppError("STATE_IMPORT_INVALID_JSON", "State import payload is not valid JSON");
+      }
+      await saveState(state);
+      return { imported: true, shortcuts: state.shortcuts.length };
+    }
+    default:
+      return null;
+  }
 }


### PR DESCRIPTION
## Summary
- refactor `handleRuntimeMessage` from a long conditional chain into a `switch` for improved readability
- preserve all runtime message behavior and return payloads
- keep existing storage/validation/execution logic unchanged

## Validation
- make lint
- make typecheck
- make test
- make build