### PR TITLE
fix: stabilize Pages and Wiki automation workflows

### DIFF
--- a/.github/workflows/wiki-sync.yml
+++ b/.github/workflows/wiki-sync.yml
@@ -26,7 +26,14 @@ jobs:
 
       - name: Clone wiki repository
         run: |
-          git clone "https://x-access-token:${{ secrets.GITHUB_TOKEN }}@github.com/${{ github.repository }}.wiki.git" wiki
+          mkdir wiki
+          git -C wiki init
+          git -C wiki config user.name "github-actions[bot]"
+          git -C wiki config user.email "github-actions[bot]@users.noreply.github.com"
+          git -C wiki remote add origin "https://x-access-token:${{ secrets.GITHUB_TOKEN }}@github.com/${{ github.repository }}.wiki.git"
+          git -C wiki fetch origin || true
+          git -C wiki checkout -B master
+          git -C wiki pull --rebase origin master || true
 
       - name: Build wiki pages from docs
         run: |
@@ -35,8 +42,6 @@ jobs:
       - name: Commit and push wiki updates
         run: |
           cd wiki
-          git config user.name "github-actions[bot]"
-          git config user.email "github-actions[bot]@users.noreply.github.com"
           git add .
           git diff --staged --quiet || git commit -m "docs: sync wiki from markdown"
-          git push
+          git push origin master

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -5,15 +5,21 @@ repo_url: https://github.com/dmoliveira/my_http_shortcuts
 theme:
   name: mkdocs
 nav:
-  - Home: docs/index.md
-  - Getting Started: docs/getting-started.md
+  - Home: index.md
+  - Getting Started: getting-started.md
   - Runbooks:
-      - Extension Smoke Test: docs/runbooks/extension-smoke-test.md
-      - Debugging: docs/runbooks/debugging.md
-      - Release: docs/runbooks/release.md
-      - Dependency Gate: docs/runbooks/dependency-gate.md
-      - Validation Blocker Log: docs/runbooks/validation-blocker-log.md
+      - Extension Smoke Test: runbooks/extension-smoke-test.md
+      - Debugging: runbooks/debugging.md
+      - Release: runbooks/release.md
+      - Dependency Gate: runbooks/dependency-gate.md
+      - Validation Blocker Log: runbooks/validation-blocker-log.md
   - Planning & Specs:
-      - Chrome Extension Plan: docs/plan/chrome-extension-plan.md
-      - Execution Contract: docs/specs/execution-contract.md
-  - Support: docs/support-the-project.md
+      - Chrome Extension Plan: plan/chrome-extension-plan.md
+      - Execution Contract: specs/execution-contract.md
+  - Reports:
+      - Release Notes Draft: release-notes-draft.md
+      - Dependency Security Report: dependency-security-report.md
+      - Dependency Unblock Packet: dependency-unblock-packet.md
+  - Assets:
+      - Hero Image Generation: assets/hero-image-generation.md
+  - Support: support-the-project.md


### PR DESCRIPTION
## Summary
- fix mkdocs nav paths to be docs-root relative for strict pages build
- include remaining markdown docs in site nav to avoid omitted-page warnings
- make wiki sync workflow bootstrap a wiki repo when initial clone/pull is unavailable

## Validation
- make release-check-smoke
- make release-notes-smoke
- python venv mkdocs build --strict