### PR TITLE
fix: make wiki sync resilient before first wiki page

### DIFF
--- a/.github/workflows/wiki-sync.yml
+++ b/.github/workflows/wiki-sync.yml
@@ -24,7 +24,18 @@ jobs:
         with:
           node-version: "22"
 
+      - name: Check wiki repository availability
+        id: wiki-check
+        run: |
+          if git ls-remote "https://x-access-token:${{ secrets.GITHUB_TOKEN }}@github.com/${{ github.repository }}.wiki.git" > /dev/null 2>&1; then
+            echo "available=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "available=false" >> "$GITHUB_OUTPUT"
+            echo "::warning::Wiki git repository is not initialized yet. Create your first wiki page in GitHub UI, then rerun this workflow."
+          fi
+
       - name: Clone wiki repository
+        if: steps.wiki-check.outputs.available == 'true'
         run: |
           mkdir wiki
           git -C wiki init
@@ -36,10 +47,12 @@ jobs:
           git -C wiki pull --rebase origin master || true
 
       - name: Build wiki pages from docs
+        if: steps.wiki-check.outputs.available == 'true'
         run: |
           node scripts/build-wiki.mjs wiki
 
       - name: Commit and push wiki updates
+        if: steps.wiki-check.outputs.available == 'true'
         run: |
           cd wiki
           git add .

--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ Quick navigation: [Project Index](#-project-index) · [Highlights](#-highlights)
 - Full docs map: `docs/index.md`
 - GitHub Pages docs (after first pages deploy): `https://dmoliveira.github.io/my_http_shortcuts/`
 - GitHub Wiki: `https://github.com/dmoliveira/my_http_shortcuts/wiki` (auto-synced from markdown docs)
+- Wiki bootstrap runbook: `docs/runbooks/wiki-bootstrap.md`
 - Debugging guide: `docs/runbooks/debugging.md`
 - Extension smoke tests: `docs/runbooks/extension-smoke-test.md`
 - Release process: `docs/runbooks/release.md`

--- a/docs/index.md
+++ b/docs/index.md
@@ -9,6 +9,7 @@
 ## Release & Operations
 
 - `docs/runbooks/release.md` - release flow and checks
+- `docs/runbooks/wiki-bootstrap.md` - one-time wiki initialization steps for sync automation
 - `docs/runbooks/dependency-gate.md` - dependency policy unblock path
 - `docs/runbooks/validation-blocker-log.md` - blocker evidence log
 - `docs/release-notes-draft.md` - generated release notes draft

--- a/docs/runbooks/wiki-bootstrap.md
+++ b/docs/runbooks/wiki-bootstrap.md
@@ -1,0 +1,18 @@
+# 📘 Wiki Bootstrap (One-Time)
+
+The wiki sync workflow publishes markdown docs into the repository wiki.
+
+## Why this may be needed
+
+GitHub wiki repositories (`<repo>.wiki.git`) are not always initialized until a first wiki page exists.
+
+If the workflow warns that the wiki repo is unavailable, run this one-time bootstrap.
+
+## One-time bootstrap steps
+
+1. Open: `https://github.com/dmoliveira/my_http_shortcuts/wiki`
+2. Click **Create the first page**
+3. Save a simple placeholder page (for example: `Home`)
+4. Re-run **Wiki Sync** workflow from Actions tab (or push a docs change)
+
+After that, wiki sync automation should push generated pages successfully.


### PR DESCRIPTION
## Summary
- add a wiki availability check in `wiki-sync.yml`
- skip sync steps gracefully until wiki repo exists, with actionable warning
- add one-time bootstrap runbook and README/docs index links

## Validation
- make release-check-smoke
- make release-notes-smoke
- git diff --check