### PR TITLE
chore: add wiki-status preflight and bootstrap hints

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@ SHELL := /bin/bash
 PROJECT := my_http_shortcuts
 VERSION := $(shell node -p "require('./package.json').version")
 
-.PHONY: help install dependency-security-report dependency-unblock-packet gate-status toolchain-check validate-local release-ready lint test typecheck build package release-notes release-notes-file release-notes-smoke release-check release-check-smoke tag
+.PHONY: help install dependency-security-report dependency-unblock-packet gate-status wiki-status toolchain-check validate-local release-ready lint test typecheck build package release-notes release-notes-file release-notes-smoke release-check release-check-smoke tag
 
 help:
 	@printf "$(PROJECT) v$(VERSION)\n"
@@ -11,6 +11,7 @@ help:
 	@printf "  make dependency-security-report Generate dependency metadata report\n"
 	@printf "  make dependency-unblock-packet Capture blocker evidence bundle\n"
 	@printf "  make gate-status    Print dependency-gate readiness\n"
+	@printf "  make wiki-status    Check wiki git backend readiness\n"
 	@printf "  make toolchain-check Verify required local binaries\n"
 	@printf "  make validate-local Run toolchain + lint/typecheck/test/build\n"
 	@printf "  make release-ready  Run release validation sequence\n"
@@ -37,6 +38,9 @@ dependency-unblock-packet:
 
 gate-status:
 	node scripts/gate-status.mjs
+
+wiki-status:
+	node scripts/wiki-status.mjs
 
 toolchain-check:
 	node scripts/toolchain-check.mjs

--- a/README.md
+++ b/README.md
@@ -89,6 +89,7 @@ make build
 make dependency-security-report
 make dependency-unblock-packet
 make gate-status
+make wiki-status
 make validate-local
 make release-ready
 ```

--- a/docs/runbooks/wiki-bootstrap.md
+++ b/docs/runbooks/wiki-bootstrap.md
@@ -8,6 +8,12 @@ GitHub wiki repositories (`<repo>.wiki.git`) are not always initialized until a 
 
 If the workflow warns that the wiki repo is unavailable, run this one-time bootstrap.
 
+Pre-check command:
+
+```bash
+make wiki-status
+```
+
 ## One-time bootstrap steps
 
 1. Open: `https://github.com/dmoliveira/my_http_shortcuts/wiki`

--- a/scripts/wiki-status.mjs
+++ b/scripts/wiki-status.mjs
@@ -1,0 +1,28 @@
+#!/usr/bin/env node
+
+import { execSync } from "node:child_process";
+
+const owner = "dmoliveira";
+const repo = "my_http_shortcuts";
+const wikiGitUrl = `https://github.com/${owner}/${repo}.wiki.git`;
+const wikiUrl = `https://github.com/${owner}/${repo}/wiki`;
+
+function checkWikiGitAvailability() {
+  try {
+    execSync(`git ls-remote ${wikiGitUrl}`, { stdio: ["ignore", "pipe", "pipe"] });
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+if (checkWikiGitAvailability()) {
+  process.stdout.write("Wiki status: available\n");
+  process.stdout.write("Wiki git backend is initialized. Wiki Sync can publish generated pages.\n");
+  process.exit(0);
+}
+
+process.stdout.write("Wiki status: not initialized\n");
+process.stdout.write("Wiki git backend is not available yet.\n");
+process.stdout.write(`Open ${wikiUrl} and create your first page, then rerun Wiki Sync.\n`);
+process.exit(1);


### PR DESCRIPTION
## Summary
- add `make wiki-status` preflight command to check wiki git backend availability
- add `scripts/wiki-status.mjs` with clear bootstrap guidance when wiki is not initialized
- document command usage in README and wiki bootstrap runbook

## Validation
- make release-check-smoke
- make release-notes-smoke
- make wiki-status (expected non-zero until first wiki page exists)
- git diff --check