### PR TITLE
chore: add wiki sync dispatch helper

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@ SHELL := /bin/bash
 PROJECT := my_http_shortcuts
 VERSION := $(shell node -p "require('./package.json').version")
 
-.PHONY: help install dependency-security-report dependency-unblock-packet gate-status wiki-status toolchain-check validate-local release-ready lint test typecheck build package release-notes release-notes-file release-notes-smoke release-check release-check-smoke tag
+.PHONY: help install dependency-security-report dependency-unblock-packet gate-status wiki-status wiki-sync-run toolchain-check validate-local release-ready lint test typecheck build package release-notes release-notes-file release-notes-smoke release-check release-check-smoke tag
 
 help:
 	@printf "$(PROJECT) v$(VERSION)\n"
@@ -12,6 +12,7 @@ help:
 	@printf "  make dependency-unblock-packet Capture blocker evidence bundle\n"
 	@printf "  make gate-status    Print dependency-gate readiness\n"
 	@printf "  make wiki-status    Check wiki git backend readiness\n"
+	@printf "  make wiki-sync-run  Dispatch wiki sync workflow if ready\n"
 	@printf "  make toolchain-check Verify required local binaries\n"
 	@printf "  make validate-local Run toolchain + lint/typecheck/test/build\n"
 	@printf "  make release-ready  Run release validation sequence\n"
@@ -41,6 +42,9 @@ gate-status:
 
 wiki-status:
 	node scripts/wiki-status.mjs
+
+wiki-sync-run:
+	node scripts/wiki-sync-run.mjs
 
 toolchain-check:
 	node scripts/toolchain-check.mjs

--- a/README.md
+++ b/README.md
@@ -90,6 +90,7 @@ make dependency-security-report
 make dependency-unblock-packet
 make gate-status
 make wiki-status
+make wiki-sync-run
 make validate-local
 make release-ready
 ```

--- a/docs/runbooks/wiki-bootstrap.md
+++ b/docs/runbooks/wiki-bootstrap.md
@@ -21,4 +21,10 @@ make wiki-status
 3. Save a simple placeholder page (for example: `Home`)
 4. Re-run **Wiki Sync** workflow from Actions tab (or push a docs change)
 
+CLI shortcut (after wiki is initialized):
+
+```bash
+make wiki-sync-run
+```
+
 After that, wiki sync automation should push generated pages successfully.

--- a/scripts/wiki-sync-run.mjs
+++ b/scripts/wiki-sync-run.mjs
@@ -1,0 +1,22 @@
+#!/usr/bin/env node
+
+import { execSync } from "node:child_process";
+
+function run(command) {
+  return execSync(command, { stdio: ["ignore", "pipe", "pipe"] }).toString().trim();
+}
+
+try {
+  const statusOutput = run("node scripts/wiki-status.mjs");
+  process.stdout.write(`${statusOutput}\n`);
+  run("gh workflow run wiki-sync.yml");
+  process.stdout.write("Triggered wiki-sync.yml workflow.\n");
+  process.exit(0);
+} catch (error) {
+  const message = error instanceof Error ? error.message : "Unknown error";
+  process.stderr.write(`${message}\n`);
+  process.stderr.write(
+    "Wiki sync dispatch skipped. Ensure wiki is initialized (create first page) and GitHub CLI auth is available.\n"
+  );
+  process.exit(1);
+}


### PR DESCRIPTION
## Summary
- add `scripts/wiki-sync-run.mjs` to dispatch wiki sync only when wiki backend is available
- add `make wiki-sync-run` and include it in command docs
- update wiki bootstrap runbook with post-init CLI command

## Validation
- make release-check-smoke
- make release-notes-smoke
- make wiki-status (expected fail until first wiki page exists)
- make wiki-sync-run (expected fail with guidance until wiki is initialized)
- git diff --check