### PR TITLE
chore: add wiki monitor workflow for post-bootstrap auto-sync

### DIFF
--- a/.github/workflows/wiki-monitor.yml
+++ b/.github/workflows/wiki-monitor.yml
@@ -1,0 +1,31 @@
+name: Wiki Monitor
+
+on:
+  schedule:
+    - cron: "*/30 * * * *"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  actions: write
+
+jobs:
+  check-and-dispatch:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check wiki backend availability
+        id: check
+        run: |
+          if git ls-remote "https://x-access-token:${{ secrets.GITHUB_TOKEN }}@github.com/${{ github.repository }}.wiki.git" > /dev/null 2>&1; then
+            echo "available=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "available=false" >> "$GITHUB_OUTPUT"
+            echo "Wiki backend not initialized yet; skipping dispatch."
+          fi
+
+      - name: Dispatch wiki sync workflow
+        if: steps.check.outputs.available == 'true'
+        run: |
+          gh workflow run wiki-sync.yml --repo "${{ github.repository }}"
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ Quick navigation: [Project Index](#-project-index) · [Highlights](#-highlights)
 - GitHub Pages docs (after first pages deploy): `https://dmoliveira.github.io/my_http_shortcuts/`
 - GitHub Wiki: `https://github.com/dmoliveira/my_http_shortcuts/wiki` (auto-synced from markdown docs)
 - Wiki bootstrap runbook: `docs/runbooks/wiki-bootstrap.md`
+- Wiki monitor workflow: `https://github.com/dmoliveira/my_http_shortcuts/actions/workflows/wiki-monitor.yml`
 - Debugging guide: `docs/runbooks/debugging.md`
 - Extension smoke tests: `docs/runbooks/extension-smoke-test.md`
 - Release process: `docs/runbooks/release.md`

--- a/docs/runbooks/wiki-bootstrap.md
+++ b/docs/runbooks/wiki-bootstrap.md
@@ -27,4 +27,8 @@ CLI shortcut (after wiki is initialized):
 make wiki-sync-run
 ```
 
+Automatic fallback:
+
+- `wiki-monitor.yml` checks wiki availability every 30 minutes and dispatches `wiki-sync.yml` automatically once initialization is detected.
+
 After that, wiki sync automation should push generated pages successfully.


### PR DESCRIPTION
## Summary
- add `wiki-monitor.yml` scheduled workflow to detect wiki backend readiness
- auto-dispatch `wiki-sync.yml` once wiki backend exists
- document monitor behavior in wiki bootstrap runbook and README links

## Validation
- make release-check-smoke
- make release-notes-smoke
- git diff --check