### PR TITLE
docs: clarify wiki bootstrap pending status guidance

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ Quick navigation: [Project Index](#-project-index) · [Highlights](#-highlights)
 - GitHub Wiki: `https://github.com/dmoliveira/my_http_shortcuts/wiki` (auto-synced from markdown docs)
 - Wiki bootstrap runbook: `docs/runbooks/wiki-bootstrap.md`
 - Wiki monitor workflow: `https://github.com/dmoliveira/my_http_shortcuts/actions/workflows/wiki-monitor.yml`
+- Current wiki status: run `make wiki-status` (shows if one-time manual bootstrap is still pending)
 - Debugging guide: `docs/runbooks/debugging.md`
 - Extension smoke tests: `docs/runbooks/extension-smoke-test.md`
 - Release process: `docs/runbooks/release.md`

--- a/docs/index.md
+++ b/docs/index.md
@@ -10,6 +10,7 @@
 
 - `docs/runbooks/release.md` - release flow and checks
 - `docs/runbooks/wiki-bootstrap.md` - one-time wiki initialization steps for sync automation
+- `make wiki-status` - quick pre-check to confirm wiki backend availability
 - `docs/runbooks/dependency-gate.md` - dependency policy unblock path
 - `docs/runbooks/validation-blocker-log.md` - blocker evidence log
 - `docs/release-notes-draft.md` - generated release notes draft

--- a/docs/runbooks/wiki-bootstrap.md
+++ b/docs/runbooks/wiki-bootstrap.md
@@ -8,11 +8,13 @@ GitHub wiki repositories (`<repo>.wiki.git`) are not always initialized until a 
 
 If the workflow warns that the wiki repo is unavailable, run this one-time bootstrap.
 
-Pre-check command:
+Current repo status may still be pending until first page is created. Check anytime with:
 
 ```bash
 make wiki-status
 ```
+
+Pre-check command (same as above) should report `Wiki status: available` before automated sync can push pages.
 
 ## One-time bootstrap steps
 


### PR DESCRIPTION
## Summary
- add explicit README/docs note to check `make wiki-status` for current wiki bootstrap state
- clarify wiki bootstrap runbook wording around pending status and expected `available` result
- keep workflow/tooling unchanged; docs-only clarity pass

## Validation
- make release-check-smoke
- make release-notes-smoke
- git diff --check