### PR TITLE
fix docs index links and enhance support messaging

### DIFF
--- a/README.md
+++ b/README.md
@@ -176,8 +176,9 @@ Then click **Reload** on the extension card in `chrome://extensions`.
 
 ## 💛 Support This Project
 
-- Donate directly via Stripe: https://buy.stripe.com/8x200i8bSgVe3Vl3g8bfO00
-- Support page: `docs/support-the-project.md`
+- Donate via Stripe: https://buy.stripe.com/8x200i8bSgVe3Vl3g8bfO00
+- Read full support options: `docs/support-the-project.md`
+- Non-monetary support: star the repo, report high-quality issues, and share UX/runbook feedback
 - Every contribution helps keep maintenance and feature delivery moving.
 
 ## 🤝 Contributing

--- a/docs/index.md
+++ b/docs/index.md
@@ -2,15 +2,15 @@
 
 ## Start Here
 
-- `docs/getting-started.md` - install, load in Chrome, and run your first shortcut
-- `docs/runbooks/extension-smoke-test.md` - manual extension testing checklist
-- `docs/runbooks/debugging.md` - troubleshooting and diagnostics workflow
+- [Getting Started](getting-started.md) - install, load in Chrome, and run your first shortcut
+- [Extension Smoke Test](runbooks/extension-smoke-test.md) - manual extension testing checklist
+- [Debugging](runbooks/debugging.md) - troubleshooting and diagnostics workflow
 - `make refresh-extension` - rebuild extension and open `chrome://extensions` for one-click reload
 
 ## Release & Operations
 
-- `docs/runbooks/release.md` - release flow and checks
-- `docs/runbooks/wiki-bootstrap.md` - one-time wiki initialization steps for sync automation
+- [Release Runbook](runbooks/release.md) - release flow and checks
+- [Wiki Bootstrap](runbooks/wiki-bootstrap.md) - one-time wiki initialization steps for sync automation
 - `make wiki-status` - quick pre-check to confirm wiki backend availability
 - `make wiki-status-json` - machine-readable wiki backend status for automation
 - `make wiki-watch` - poll for wiki bootstrap and auto-dispatch wiki sync when ready
@@ -18,20 +18,20 @@
 - `make wiki-complete` - watch, dispatch wiki sync, and verify pages in one command
 - `make wiki-pulse` - run doctor/reminder/monitor cycle for pending bootstrap (with monitor cooldown)
 - `make wiki-autopilot` - run `wiki-status --json` precheck, skip watch when uninitialized, then pulse fallback
-- `docs/runbooks/dependency-gate.md` - dependency policy unblock path
-- `docs/runbooks/validation-blocker-log.md` - blocker evidence log
-- `docs/release-notes-draft.md` - generated release notes draft
+- [Dependency Gate](runbooks/dependency-gate.md) - dependency policy unblock path
+- [Validation Blocker Log](runbooks/validation-blocker-log.md) - blocker evidence log
+- [Release Notes Draft](release-notes-draft.md) - generated release notes draft
 
 ## Plans & Specs
 
-- `docs/plan/chrome-extension-plan.md` - roadmap and implementation tracking
-- `docs/specs/execution-contract.md` - runtime behavior contract
+- [Chrome Extension Plan](plan/chrome-extension-plan.md) - roadmap and implementation tracking
+- [Execution Contract](specs/execution-contract.md) - runtime behavior contract
 
 ## Security & Validation Artifacts
 
-- `docs/dependency-security-report.md` - dependency metadata report
-- `docs/dependency-unblock-packet.md` - command evidence bundle for approval workflows
+- [Dependency Security Report](dependency-security-report.md) - dependency metadata report
+- [Dependency Unblock Packet](dependency-unblock-packet.md) - command evidence bundle for approval workflows
 
 ## Support
 
-- `docs/support-the-project.md` - donation options and sustainability note
+- [Support This Project](support-the-project.md) - donation options, non-monetary support ideas, and sustainability notes

--- a/docs/support-the-project.md
+++ b/docs/support-the-project.md
@@ -2,9 +2,16 @@
 
 If **My HTTP Shortcuts** saves you time, you can support maintenance and future improvements.
 
-## Contribute via Stripe
+## Donate
 
-- Donate here: https://buy.stripe.com/8x200i8bSgVe3Vl3g8bfO00
+- Stripe: https://buy.stripe.com/8x200i8bSgVe3Vl3g8bfO00
+
+## Other ways to help
+
+- Star and watch the repository: https://github.com/dmoliveira/my_http_shortcuts
+- Open issues with reproducible steps and expected behavior
+- Share runbook or UX feedback from real usage
+- Open focused PRs with validation notes (`lint`, `test`, `build`)
 
 ## Why support helps
 


### PR DESCRIPTION
## Summary
- replace code-formatted doc references in `docs/index.md` with clickable markdown links so docs users can navigate directly
- expand `docs/support-the-project.md` with clearer donation and non-monetary support paths
- improve README support call-to-action copy for faster contribution discovery

## Validation
- `npm run lint`
- `npm run test`
- `git diff --check`